### PR TITLE
Remove "commit SHA" from accepted `ref` values (Fixes #15)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The solution is to manually create a PAT and store it as a secret e.g. `${{ secr
 **Optional.** The inputs to pass to the workflow (if any are configured), this must be a JSON encoded string, e.g. `{ "myInput": "foobar" }`
 
 ### `ref`
-**Optional.** The Git reference used with the triggered workflow run. The reference can be a branch, tag, or a commit SHA. If omitted the context ref of the triggering workflow is used. If you want to trigger on pull requests and run the target workflow in the context of the pull request branch, set the ref to `${{ github.event.pull_request.head.ref }}`
+**Optional.** The Git reference used with the triggered workflow run. The reference can be a branch, or a tag. If omitted the context ref of the triggering workflow is used. If you want to trigger on pull requests and run the target workflow in the context of the pull request branch, set the ref to `${{ github.event.pull_request.head.ref }}`
 
 ### `repo`
 **Optional.** The default behavior is to trigger workflows in the same repo as the triggering workflow, if you wish to trigger in another GitHub repo "externally", then provide the owner + repo name with slash between them e.g. `microsoft/vscode`

--- a/action.yaml
+++ b/action.yaml
@@ -12,7 +12,7 @@ inputs:
     description: 'Inputs to pass to the workflow, must be a JSON string'
     required: false
   ref:
-    description: 'The reference of the workflow run. The reference can be a branch, tag, or a commit SHA'
+    description: 'The reference of the workflow run. The reference can be a branch or a tag'
     required: false
   repo:
     description: 'Repo owner & name, slash separated, only set if invoking a workflow in a different repo'


### PR DESCRIPTION
Per:

https://docs.github.com/en/rest/reference/actions#create-a-workflow-dispatch-event

> The git reference for the workflow. The reference can be a branch or tag name.