### PR TITLE
Set the workflow id  as output

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The solution is to manually create a PAT and store it as a secret e.g. `${{ secr
 
 
 ## Outputs
-None
+This Action emits a single output named workflowId.
 
 
 ## Example usage

--- a/src/main.ts
+++ b/src/main.ts
@@ -53,7 +53,7 @@ async function run(): Promise<void> {
       inputs: inputs
     })
     core.info(`API response status: ${dispatchResp.status} 🚀`)
-    core.setOutput('response', dispatchResp.status);
+    core.setOutput('workflowId', workflowFind.id);
   } catch (error) {
     core.setFailed(error.message)
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -53,6 +53,7 @@ async function run(): Promise<void> {
       inputs: inputs
     })
     core.info(`API response status: ${dispatchResp.status} 🚀`)
+    core.setOutput('response', dispatchResp.status);
   } catch (error) {
     core.setFailed(error.message)
   }


### PR DESCRIPTION
This enable us to wait on the specific id of the workflow run