### PR TITLE
Allow specifying workflow by path

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ For details of the `workflow_dispatch` even see [this blog post introducing this
 
 ## Inputs
 ### `workflow`
-**Required.** The name or ID of the workflow to trigger and run. This is the name declared in the YAML, not the filename
+**Required.** The name (as declared in the YAML), ID (as returned by the Github API) or path of the workflow (e.g. `.github/workflows/ci.yml`) to trigger and run.
 
 ### `token`
 

--- a/action.yaml
+++ b/action.yaml
@@ -3,7 +3,7 @@ description: 'Trigger and chain GitHub Actions workflows with workflow_dispatch 
 
 inputs:
   workflow: 
-    description: 'Name or ID of workflow to run'
+    description: 'Name, ID or path of workflow to run'
     required: true
   token: 
     description: 'GitHub token with repo write access, can NOT use secrets.GITHUB_TOKEN, see readme'

--- a/dist/index.js
+++ b/dist/index.js
@@ -566,7 +566,7 @@ function run() {
             core.debug(JSON.stringify(workflows, null, 3));
             core.debug('### END:  List Workflows response data');
             // Locate workflow either by name or id
-            const workflowFind = workflows.find((workflow) => workflow.name === workflowRef || workflow.id.toString() === workflowRef);
+            const workflowFind = workflows.find((workflow) => workflow.name === workflowRef || workflow.id.toString() === workflowRef || workflow.path === workflowRef);
             if (!workflowFind)
                 throw new Error(`Unable to find workflow '${workflowRef}' in ${owner}/${repo} 😥`);
             console.log(`Workflow id is: ${workflowFind.id}`);

--- a/src/main.ts
+++ b/src/main.ts
@@ -43,7 +43,7 @@ async function run(): Promise<void> {
     core.debug('### END:  List Workflows response data')
 
     // Locate workflow either by name or id
-    const workflowFind = workflows.find((workflow) => workflow.name === workflowRef || workflow.id.toString() === workflowRef)
+    const workflowFind = workflows.find((workflow) => workflow.name === workflowRef || workflow.id.toString() === workflowRef || workflow.path === workflowRef)
     if(!workflowFind) throw new Error(`Unable to find workflow '${workflowRef}' in ${owner}/${repo} 😥`)
     console.log(`Workflow id is: ${workflowFind.id}`)
 


### PR DESCRIPTION
Previously, workflow-dispatch only allows specifying the workflow by ID (as returned by the API) or by name (as specified in the YAML). Specifying by ID is problematic because the ID is auto-generated by Github, so we don't know what the ID is before we push, and the ID can differ per repository fork. Specifying by name (in the YAML) is also problematic because the until you've pushed this workflow to the main branch, Github doesn't read its name, and thus workflow-dispatch fails to find a workflow with that name.

This pull request allows specifying a workflow by path. This always works even when introducing a workflow for the first time in a branch.

Closes #18.