### PR TITLE
Upgrade node12 to node16 due to node 12 deprecation

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -19,7 +19,7 @@ inputs:
     required: false 
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'
 
 branding:


### PR DESCRIPTION
Upgrade from node12 to node16 (due to a deprecation warning in a workflow's summary):
<img width="781" alt="Screenshot 2022-10-19 at 16 33 51" src="https://user-images.githubusercontent.com/74499051/196692132-266832f0-56d7-4bd4-a44f-d61c7d7fded0.png">
