### PR TITLE
Fix: Information related to tokens in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,13 @@ For details of the `workflow_dispatch` even see [this blog post introducing this
 
 ### `token`
 
-**Required.** A GitHub access token (PAT) with write access to the repo in question. **NOTE.** The automatically provided token e.g. `${{ secrets.GITHUB_TOKEN }}` can not be used, GitHub prevents this token from being able to fire the  `workflow_dispatch` and `repository_dispatch` event. [The reasons are explained in the docs](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#triggering-new-workflows-using-a-personal-access-token).  
+**Required.** A GitHub access token with write access to the repo in question. **NOTE.** The automatically provided token e.g. `${{ secrets.GITHUB_TOKEN }}` can only be used if you are calling the same repo. In this case you must assign the permission `action: write` to the token, see [permissions api](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs). Example:
+```yaml
+permissions:
+  actions: write
+```
 
-The solution is to manually create a PAT and store it as a secret e.g. `${{ secrets.PERSONAL_TOKEN }}`
+The solution to trigger other repositories is to manually create a PAT and store it as a secret e.g. `${{ secrets.PERSONAL_TOKEN }}`.
 
 ### `inputs`
 **Optional.** The inputs to pass to the workflow (if any are configured), this must be a JSON encoded string, e.g. `{ "myInput": "foobar" }`


### PR DESCRIPTION
Fix documentation related to tokens. The secrets.GITHUB_TOKEN provided by the GitHub Actions App can do everything related to the repo if we [elevate its permissions](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs), including calling workflow_dispatch and repository_dispatch.

Some people in my organization are using PAT's instead of the secrets.GITHUB_TOKEN when using this action because of the README suggestion, even when they are calling the same repository. Using PATs in that context provides unnecessary security risks.

#### Testing

1. Create two workflows:

---

`trigger.yaml`
```yaml
name: Trigger

on:
  workflow_dispatch:

permissions:
  actions: write

jobs:
  workflowdispatch:
    runs-on: ubuntu-latest
    steps:
      - uses: benc-uk/workflow-dispatch@v1
        with:
          workflow: triggered.yaml
          token: ${{ secrets.GITHUB_TOKEN }}
```

---

`triggered.yaml`
```yaml
name: Triggered

on:
  workflow_dispatch:

jobs:
  read:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/github-script@v6
        with:
          result-encoding: string
          script: |
            const fs = require("fs")
            const eventPath = '${{ github.event_path }}' 
            fs.readFile(eventPath, "utf-8", (err, data) => {
              console.log(data)
              console.error(err)
            })
            return eventPath
```

---

2. Manually run the `Trigger` workflow
3. See the `Triggered` workflow will also run