### PR TITLE
docs: add required token field when calling external workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,4 +69,5 @@ This Action emits a single output named `workflowId`.
     workflow: my-workflow.yaml
     repo: benc-uk/example
     inputs: '{ "message": "blah blah", "something": false }'
+    token: ${{ steps.generate_token.outputs.token }} # Required when using the `repo` option. Either a PAT or a token generated from a GitHub App (eg by https://github.com/tibdex/github-app-token)
 ```


### PR DESCRIPTION
Since the token field is required when calling an external workflow, I think it should be added to the example as well. Would have saved me an hour or so 😄 