### PR TITLE
Fix issue when a wrong workflowRef is used

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -55,7 +55,8 @@ async function run(): Promise<void> {
     const foundWorkflow = workflows.find((workflow) => {
       return workflow.name === workflowRef ||
         workflow.id.toString() === workflowRef ||
-        workflow.path.endsWith(`/${workflowRef}`) // add a leading / to avoid matching workflow with same suffix
+        workflow.path.endsWith(`/${workflowRef}`) || // Add a leading / to avoid matching workflow with same suffix
+        workflow.path == workflowRef // Or it stays in top level directory
     })
 
     if(!foundWorkflow) throw new Error(`Unable to find workflow '${workflowRef}' in ${owner}/${repo} 😥`)

--- a/src/main.ts
+++ b/src/main.ts
@@ -55,7 +55,7 @@ async function run(): Promise<void> {
     const foundWorkflow = workflows.find((workflow) => {
       return workflow.name === workflowRef ||
         workflow.id.toString() === workflowRef ||
-        workflow.path.endsWith(workflowRef)
+        workflow.path.endsWith(`/${workflowRef}`) // add a leading / to avoid matching workflow with same suffix
     })
 
     if(!foundWorkflow) throw new Error(`Unable to find workflow '${workflowRef}' in ${owner}/${repo} 😥`)


### PR DESCRIPTION
Fix an issue when one workflow file ends with the same suffix of another workflow.

For example, `run-the-build.yml` may got picked up instead of `build.yml`.