### PR TITLE
Use alternate `ref` default for PRs

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -15,6 +15,7 @@ inputs:
   ref:
     description: "The reference can be a branch, tag, or a commit SHA"
     required: false
+    default: ${{ github.head_ref || github.ref }}
   repo:
     description: "Repo owner & name, slash separated, only set if invoking a workflow in a different repo"
     required: false

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,7 +26,7 @@ async function run(): Promise<void> {
 
     // Optional inputs, with defaults
     const token = core.getInput('token')
-    const ref = core.getInput('ref') || github.context.ref
+    const ref = core.getInput('ref')
     const [owner, repo] = core.getInput('repo')
       ? core.getInput('repo').split('/')
       : [github.context.repo.owner, github.context.repo.repo]


### PR DESCRIPTION
When using this action in PRs the default for a `github.ref` is `refs/pull/<pr_number>/merge`. Using the current default would get you the following error:
```
Error: No ref found for: refs/pull/3508/merge - https://docs.github.com/rest/actions/workflows#create-a-workflow-dispatch-event
```
This PR updates the default to use `github.head_ref` for PRs (this value is only set for PRs) and otherwise use `github.ref`.