### PR TITLE
Adding the wait-interval-seconds input

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GitHub Action for Dispatching Workflows
 
-This action triggers another GitHub Actions workflow, using the `workflow_dispatch` event.  
+This action triggers another GitHub Actions workflow, using the `workflow_dispatch` event.
 The workflow must be configured for this event type e.g. `on: [workflow_dispatch]`
 
 This allows you to chain workflows, the classic use case is have a CI build workflow, trigger a CD release/deploy workflow when it completes. Allowing you to maintain separate workflows for CI and CD, and pass data between them as required.
@@ -63,6 +63,10 @@ This option is also left for backwards compatibility with older versions where t
 ### `wait-timeout-seconds`
 
 **Optional.** The maximum time in seconds to wait for the triggered workflow run to complete before timing out. This only applies if `wait-for-completion` is set to `true`. Default is `900` seconds (15 minutes).
+
+### `wait-interval-seconds`
+
+**Optional.** Interval in seconds between polls. This only applies if `wait-for-completion` is set to `true`. Default is `5` seconds.
 
 ### `sync-status`
 

--- a/action.yaml
+++ b/action.yaml
@@ -27,6 +27,10 @@ inputs:
     description: 'Maximum time in seconds to wait for the workflow run to complete before timing out (only applies if wait-for-completion is true)'
     required: false
     default: 900
+  wait-interval-seconds:
+    description: 'Interval in seconds between polls (only applies if wait-for-completion is true)'
+    required: false
+    default: 5
   sync-status:
     description: 'Whether to set the status of this action to failed if the triggered workflow run fails, or is cancelled. Only applies if wait-for-completion is true.'
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -23633,6 +23633,7 @@ async function run() {
     const waitForCompletion = getInput("wait-for-completion") === "true";
     const syncStatus = getInput("sync-status") === "true";
     const timeoutSeconds = parseInt(getInput("wait-timeout-seconds") || "900", 10);
+    const waitIntervalSeconds = parseInt(getInput("wait-interval-seconds") || "5", 10);
     let runStatus = "in_progress";
     if (waitForCompletion) {
       info(`\u23F3 Waiting for workflow run to complete with a timeout of ${timeoutSeconds} seconds...`);
@@ -23646,7 +23647,7 @@ Note: The workflow is still running but we have stopped waiting. You can check t
           runStatus = "timed_out";
           break;
         }
-        await new Promise((resolve) => setTimeout(resolve, 5e3));
+        await new Promise((resolve) => setTimeout(resolve, waitIntervalSeconds * 1e3));
         const { data: runData } = await octokit.request(
           `GET /repos/${owner}/${repo}/actions/runs/${dispatchResp.data.workflow_run_id}`
         );

--- a/src/main.ts
+++ b/src/main.ts
@@ -90,6 +90,7 @@ async function run(): Promise<void> {
     const waitForCompletion = core.getInput('wait-for-completion') === 'true'
     const syncStatus = core.getInput('sync-status') === 'true'
     const timeoutSeconds = parseInt(core.getInput('wait-timeout-seconds') || '900', 10) // Default to 15 minutes
+    const waitIntervalSeconds = parseInt(core.getInput('wait-interval-seconds') || '5', 10) // Default to 5 seconds
     let runStatus = 'in_progress'
 
     // Polling loop to check workflow run status until it completes or times out
@@ -105,7 +106,7 @@ async function run(): Promise<void> {
           break
         }
 
-        await new Promise((resolve) => setTimeout(resolve, 5000)) // Wait for 5 seconds before polling again
+        await new Promise((resolve) => setTimeout(resolve, waitIntervalSeconds * 1000)) // Wait for waitIntervalSeconds before polling again
 
         const { data: runData } = await octokit.request(
           `GET /repos/${owner}/${repo}/actions/runs/${dispatchResp.data.workflow_run_id}`,


### PR DESCRIPTION
Adding the option to configure the wait interval. It was hardcoded to 5 seconds, which is a bit short for long running jobs