### PR TITLE
Pin GitHub REST API version to 2026-03-10

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -23587,6 +23587,7 @@ function getOctokit(token, options, ...additionalPlugins) {
 var version = "1.3.0";
 
 // src/main.ts
+var API_VERSION = "2026-03-10";
 async function run() {
   info(`\u{1F3C3} Workflow Dispatch Action v${version}`);
   try {
@@ -23626,7 +23627,7 @@ async function run() {
         ref,
         inputs,
         return_run_details: true,
-        headers: { "x-github-api-version": "2026-03-10" }
+        headers: { "x-github-api-version": API_VERSION }
       }
     );
     info(`\u{1F3C6} API response status: ${dispatchResp.status}`);
@@ -23650,7 +23651,10 @@ Note: The workflow is still running but we have stopped waiting. You can check t
         }
         await new Promise((resolve) => setTimeout(resolve, waitIntervalSeconds * 1e3));
         const { data: runData } = await octokit.request(
-          `GET /repos/${owner}/${repo}/actions/runs/${dispatchResp.data.workflow_run_id}`
+          `GET /repos/${owner}/${repo}/actions/runs/${dispatchResp.data.workflow_run_id}`,
+          {
+            headers: { "x-github-api-version": API_VERSION }
+          }
         );
         runStatus = runData.status;
         info(`\u{1F504} Current run status: ${runStatus}`);
@@ -23669,7 +23673,10 @@ Note: The workflow is still running but we have stopped waiting. You can check t
     setOutput("workflowId", foundWorkflow.id);
     if (syncStatus && waitForCompletion) {
       const { data: finalRunData } = await octokit.request(
-        `GET /repos/${owner}/${repo}/actions/runs/${dispatchResp.data.workflow_run_id}`
+        `GET /repos/${owner}/${repo}/actions/runs/${dispatchResp.data.workflow_run_id}`,
+        {
+          headers: { "x-github-api-version": API_VERSION }
+        }
       );
       const conclusion = finalRunData.conclusion;
       if (conclusion === "failure") {

--- a/dist/index.js
+++ b/dist/index.js
@@ -23604,7 +23604,13 @@ async function run() {
         error(`Failed to parse 'inputs' JSON string: ${e instanceof Error ? e.message : String(e)}`);
       }
     }
-    const octokit = getOctokit(token);
+    const octokit = getOctokit(token, {
+      request: {
+        headers: {
+          "X-GitHub-Api-Version": API_VERSION
+        }
+      }
+    });
     const workflows = await octokit.paginate(
       octokit.rest.actions.listRepoWorkflows.endpoint.merge({
         owner,
@@ -23626,8 +23632,7 @@ async function run() {
       {
         ref,
         inputs,
-        return_run_details: true,
-        headers: { "x-github-api-version": API_VERSION }
+        return_run_details: true
       }
     );
     info(`\u{1F3C6} API response status: ${dispatchResp.status}`);
@@ -23651,10 +23656,7 @@ Note: The workflow is still running but we have stopped waiting. You can check t
         }
         await new Promise((resolve) => setTimeout(resolve, waitIntervalSeconds * 1e3));
         const { data: runData } = await octokit.request(
-          `GET /repos/${owner}/${repo}/actions/runs/${dispatchResp.data.workflow_run_id}`,
-          {
-            headers: { "x-github-api-version": API_VERSION }
-          }
+          `GET /repos/${owner}/${repo}/actions/runs/${dispatchResp.data.workflow_run_id}`
         );
         runStatus = runData.status;
         info(`\u{1F504} Current run status: ${runStatus}`);

--- a/dist/index.js
+++ b/dist/index.js
@@ -23584,7 +23584,7 @@ function getOctokit(token, options, ...additionalPlugins) {
 }
 
 // package.json
-var version = "1.3.0";
+var version = "1.3.2";
 
 // src/main.ts
 var API_VERSION = "2026-03-10";

--- a/dist/index.js
+++ b/dist/index.js
@@ -23625,7 +23625,8 @@ async function run() {
       {
         ref,
         inputs,
-        return_run_details: true
+        return_run_details: true,
+        headers: { "x-github-api-version": "2026-03-10" }
       }
     );
     info(`\u{1F3C6} API response status: ${dispatchResp.status}`);

--- a/dist/index.js
+++ b/dist/index.js
@@ -23604,13 +23604,7 @@ async function run() {
         error(`Failed to parse 'inputs' JSON string: ${e instanceof Error ? e.message : String(e)}`);
       }
     }
-    const octokit = getOctokit(token, {
-      request: {
-        headers: {
-          "X-GitHub-Api-Version": API_VERSION
-        }
-      }
-    });
+    const octokit = getOctokit(token);
     const workflows = await octokit.paginate(
       octokit.rest.actions.listRepoWorkflows.endpoint.merge({
         owner,
@@ -23632,7 +23626,8 @@ async function run() {
       {
         ref,
         inputs,
-        return_run_details: true
+        return_run_details: true,
+        headers: { "x-github-api-version": API_VERSION }
       }
     );
     info(`\u{1F3C6} API response status: ${dispatchResp.status}`);
@@ -23656,7 +23651,10 @@ Note: The workflow is still running but we have stopped waiting. You can check t
         }
         await new Promise((resolve) => setTimeout(resolve, waitIntervalSeconds * 1e3));
         const { data: runData } = await octokit.request(
-          `GET /repos/${owner}/${repo}/actions/runs/${dispatchResp.data.workflow_run_id}`
+          `GET /repos/${owner}/${repo}/actions/runs/${dispatchResp.data.workflow_run_id}`,
+          {
+            headers: { "x-github-api-version": API_VERSION }
+          }
         );
         runStatus = runData.status;
         info(`\u{1F504} Current run status: ${runStatus}`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "workflow-dispatch",
-  "version": "1.3.0",
+  "version": "1.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "workflow-dispatch",
-      "version": "1.3.0",
+      "version": "1.3.2",
       "license": "MIT",
       "devDependencies": {
         "@actions/core": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow-dispatch",
-  "version": "1.3.0",
+  "version": "1.3.2",
   "author": "Ben Coleman",
   "license": "MIT",
   "description": "Trigger running GitHub Actions workflows",

--- a/src/main.ts
+++ b/src/main.ts
@@ -45,7 +45,13 @@ async function run(): Promise<void> {
     }
 
     // Get octokit client for making API calls
-    const octokit = github.getOctokit(token)
+    const octokit = github.getOctokit(token, {
+      request: {
+        headers: {
+          'X-GitHub-Api-Version': API_VERSION,
+        },
+      },
+    })
 
     // List workflows via API, and handle paginated results
     const workflows: Workflow[] = await octokit.paginate(
@@ -82,7 +88,6 @@ async function run(): Promise<void> {
         ref: ref,
         inputs: inputs,
         return_run_details: true,
-        headers: { 'x-github-api-version': API_VERSION },
       },
     )
 
@@ -113,9 +118,6 @@ async function run(): Promise<void> {
 
         const { data: runData } = await octokit.request(
           `GET /repos/${owner}/${repo}/actions/runs/${dispatchResp.data.workflow_run_id}`,
-          {
-            headers: { 'x-github-api-version': API_VERSION },
-          },
         )
         runStatus = runData.status
         core.info(`🔄 Current run status: ${runStatus}`)

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,8 @@ import * as core from '@actions/core'
 import * as github from '@actions/github'
 import * as PackageJSON from '../package.json'
 
+const API_VERSION = '2026-03-10' // Latest API version as of March 2026, update as needed
+
 type Workflow = {
   id: number
   name: string
@@ -80,7 +82,7 @@ async function run(): Promise<void> {
         ref: ref,
         inputs: inputs,
         return_run_details: true,
-        headers: { 'x-github-api-version': '2026-03-10' },
+        headers: { 'x-github-api-version': API_VERSION },
       },
     )
 
@@ -111,6 +113,9 @@ async function run(): Promise<void> {
 
         const { data: runData } = await octokit.request(
           `GET /repos/${owner}/${repo}/actions/runs/${dispatchResp.data.workflow_run_id}`,
+          {
+            headers: { 'x-github-api-version': API_VERSION },
+          },
         )
         runStatus = runData.status
         core.info(`🔄 Current run status: ${runStatus}`)
@@ -135,6 +140,9 @@ async function run(): Promise<void> {
       // Get the final conclusion of the workflow run if we were waiting for completion
       const { data: finalRunData } = await octokit.request(
         `GET /repos/${owner}/${repo}/actions/runs/${dispatchResp.data.workflow_run_id}`,
+        {
+          headers: { 'x-github-api-version': API_VERSION },
+        },
       )
       const conclusion = finalRunData.conclusion
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -45,13 +45,7 @@ async function run(): Promise<void> {
     }
 
     // Get octokit client for making API calls
-    const octokit = github.getOctokit(token, {
-      request: {
-        headers: {
-          'X-GitHub-Api-Version': API_VERSION,
-        },
-      },
-    })
+    const octokit = github.getOctokit(token)
 
     // List workflows via API, and handle paginated results
     const workflows: Workflow[] = await octokit.paginate(
@@ -88,6 +82,7 @@ async function run(): Promise<void> {
         ref: ref,
         inputs: inputs,
         return_run_details: true,
+        headers: { 'x-github-api-version': API_VERSION },
       },
     )
 
@@ -118,6 +113,9 @@ async function run(): Promise<void> {
 
         const { data: runData } = await octokit.request(
           `GET /repos/${owner}/${repo}/actions/runs/${dispatchResp.data.workflow_run_id}`,
+          {
+            headers: { 'x-github-api-version': API_VERSION },
+          },
         )
         runStatus = runData.status
         core.info(`🔄 Current run status: ${runStatus}`)

--- a/src/main.ts
+++ b/src/main.ts
@@ -80,6 +80,7 @@ async function run(): Promise<void> {
         ref: ref,
         inputs: inputs,
         return_run_details: true,
+        headers: { 'x-github-api-version': '2026-03-10' },
       },
     )
 


### PR DESCRIPTION
## Summary

Explicitly pin the GitHub REST API version by sending the `x-github-api-version: 2026-03-10` header on all Octokit requests made by the action (workflow dispatch + run-status polling).

Fixes #99.

## Why

`@actions/github`'s Octokit only auto-injects the `X-GitHub-Api-Version` header for typed `octokit.rest.<resource>.<method>()` calls. The three call sites in `src/main.ts` use the generic `octokit.request(...)` form, which bypasses that and triggers a `Deprecation` header / warning on every run (scheduled removal 2028-03-10):

> [@octokit/request] "POST .../dispatches" is deprecated. It is scheduled to be removed on Fri, 10 Mar 2028 00:00:00 GMT.

Pinning the version also makes the action's behaviour deterministic and avoids surprise regressions when GitHub rolls a new default.

## Changes

- `src/main.ts`: introduce an `API_VERSION` constant (`2026-03-10`) and attach `x-github-api-version` headers to:
  - `POST /repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches`
  - the in-loop `GET /repos/{owner}/{repo}/actions/runs/{run_id}` poll
  - the final `GET /repos/{owner}/{repo}/actions/runs/{run_id}` lookup used to read the conclusion
- `package.json`: bump version to `1.3.2`
- `dist/index.js`: rebuilt bundle to match `src/`

## Notes for reviewer

- No public input/output surface changes; `action.yaml` is unchanged.
- The `API_VERSION` constant carries a comment noting it should be bumped periodically as GitHub publishes newer dated versions.
- The existing `listRepoWorkflows` call uses the typed REST method, so it already sends the header and is unaffected.
